### PR TITLE
lock-pydantic-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alibaba-cloud-ops-mcp-server"
-version = "0.9.6"
+version = "0.9.7"
 description = "A MCP server for Alibaba Cloud"
 readme = "README.md"
 authors = [
@@ -14,7 +14,8 @@ dependencies = [
     "alibabacloud_oss_v2>=1.1.0",
     "alibabacloud-credentials>=1.0.0",
     "click>=8.1.8",
-    "fastmcp==2.8.0"
+    "fastmcp==2.8.0",
+    "pydantic==2.11.3"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "alibaba-cloud-ops-mcp-server"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "." }
 dependencies = [
     { name = "alibabacloud-cms20190101" },
@@ -126,6 +126,7 @@ dependencies = [
     { name = "alibabacloud-oss-v2" },
     { name = "click" },
     { name = "fastmcp" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -143,6 +144,7 @@ requires-dist = [
     { name = "alibabacloud-oss-v2", specifier = ">=1.1.0" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "fastmcp", specifier = "==2.8.0" },
+    { name = "pydantic", specifier = "==2.11.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
To resolve the version conflict between pydantic and fastmcp, lock pydantic version to 2.11.3